### PR TITLE
Updates file path to resolve for no extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@
 /// <reference path="../lib/phaser.d.ts"/>
 import * as Phaser from 'phaser'
 
-import {BootState} from './states/boot.ts'
-import {SplashState} from './states/splash.ts'
-import {GameState} from './states/game.ts'
+import {BootState} from './states/boot'
+import {SplashState} from './states/splash'
+import {GameState} from './states/game'
 
 class Game extends Phaser.Game {
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,9 @@ module.exports = {
     ]
   },
   devtool: 'cheap-source-map',
+  resolve: {
+    extensions: ['', '.ts', '.js']
+  },
   output: {
     pathinfo: true,
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
As soon as I open VS Code the `.ts` in the import path was being highlighted as an error and it's a simple enough change to the webpack config to fix so that's it.